### PR TITLE
API endpoint with product ID param responds with JSON of photos w/ matching ID

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": [
     "@babel/preset-env",
-    "@babel/preset-react",
-    "@babel/preset-es2015"
+    "@babel/preset-react"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@babel/core": "^7.11.6",
     "@babel/preset-env": "^7.11.5",
-    "@babel/preset-es2015": "^7.0.0-beta.53",
     "@babel/preset-react": "^7.10.4",
     "babel-loader": "^8.1.0",
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor",

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,10 @@ app.use(express.urlencoded({ extended: true }));
 
 app.use(express.static(__dirname + '/../public'));
 
+app.get('/products/:id', (req, res) => {
+  console.log('params are', req.params);
+
+})
 
 app.listen(PORT, () => {
   console.log(`listening on port ${PORT}`);

--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,7 @@ app.get('/products/:id', (req, res) => {
     // we don't want -- response[0] is an array of all photos that match the
     // request productId
     .then(response => res.json(response[0]));
-})
+});
 
 app.listen(PORT, () => {
   console.log(`listening on port ${PORT}`);


### PR DESCRIPTION
Had to shift around my database setup because it was re-initializing each time the file ran. This should have been a separate PR but came up during implementing API. 

API /products/:id endpoint responds with JSON of all photo URLs that are associated with that product ID. 