### PR TITLE
Cleanup of index.js - can handle multiple requests for photos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5951,6 +5951,131 @@
         }
       }
     },
+    "jest-tobetype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-tobetype/-/jest-tobetype-1.2.3.tgz",
+      "integrity": "sha512-9wVkY9lDW4BhcUc0Hpc0hq7n1i/erZW59RbGMl+oAi4IKPi4YtaXHdJgQg0QMDPWtK5PiM82hw6jPbVjH61Z5A==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^24.3.0",
+        "jest-matcher-utils": "^24.7.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^13.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "*",
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "13.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
+          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+          "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+          "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "diff-sequences": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+          "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+          "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-diff": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "pretty-format": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        }
+      }
+    },
     "jest-util": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor",
     "faker": "^5.1.0",
     "jest": "^26.4.2",
+    "jest-tobetype": "^1.2.3",
     "nodemon": "^2.0.4",
     "webpack": "^2.7.0",
     "webpack-cli": "^3.3.12"

--- a/server/index.js
+++ b/server/index.js
@@ -7,20 +7,47 @@ const PORT = 3001;
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// variable to ensure we only connect to the database on the first request
+let connectedToDB = false;
+
 // serve static html file on root request
 app.use(express.static(__dirname + '/../public'));
 
-// respond to a request with an id param with all photos matching that product id
+// respond to a request with an id param with array of
+// all photos matching that product id
 app.get('/products/:id', (req, res) => {
-  db.connectAsync()
-    .then(() => db.queryAsync(`USE imageCarousel`))
-    .then(() => db.queryAsync(`
-    SELECT Photos.id, product, url FROM Products INNER JOIN Photos ON Products.id = Photos.productID WHERE Products.id = ${req.params.id}`))
+  // this variable simplifies our db queries -- it asks for an array of objects of
+  // photo data that has the photo ID, its url, and the name of the product
+  var photoReq = `
+  SELECT
+  Photos.id, product, url
+  FROM Products
+  INNER JOIN Photos
+  ON Products.id = Photos.productID
+  WHERE Products.id = ${req.params.id}`;
 
-    // use response[0] because MySQL also sends back additional information
-    // we don't want -- response[0] is an array of all photos that match the
-    // request productId
-    .then(response => res.json(response[0]));
+  // we check for the var connectedToDV because we only want to connect once,
+  // if we try to connect multiple times we get an error because we try to connect
+  // while we are already connected -- the first call connects to our imageCarousel
+  // database and sets connectedToDB to true so we can simply query from that point on
+  if (!connectedToDB) {
+    db.connectAsync()
+      .then(() => db.queryAsync(`USE imageCarousel`))
+      .then(() => db.queryAsync(photoReq))
+      // use response[0] because MySQL also sends back additional information
+      // we don't want -- response[0] is an array of all photos that match the
+      // request productId
+      .then(dbResults => {
+        connectedToDB = true;
+        res.json(dbResults[0]);
+      });
+  } else {
+    db.queryAsync(photoReq)
+      // see note about request above for why dbResults[0] is sent
+      .then(dbResults => {
+        res.json(dbResults[0]);
+      });
+  }
 });
 
 app.listen(PORT, () => {

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -1,6 +1,8 @@
 const jest = require('jest');
 const app = require('./index.js');
 const axios = require('axios');
+import toBeType from "jest-tobetype";
+expect.extend(toBeType);
 
 describe('server', () => { // start of server tests
 
@@ -14,6 +16,68 @@ describe('server', () => { // start of server tests
       });
   });
 
-  // TODO: additional tests when there is additional server functionality
+  test('request to /products/:id is successful', () => {
+    return axios.get('http://localhost:3001/products/1')
+      .then(response => {
+        return expect(response.status).toBe(200);
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  test('request to /products/:id responds with array', () => {
+    return axios.get('http://localhost:3001/products/1')
+      .then(response => {
+        return expect(response.data).toBeType('array');
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  test('array response full of objects', () => {
+    return axios.get('http://localhost:3001/products/1')
+      .then(response => {
+        return expect(response.data[0]).toBeType('object');
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  describe('photo objects have id, product, url properties', () => { // photo object tests
+
+    test('test photo object id', () => {
+      return axios.get('http://localhost:3001/products/1')
+        .then(response => {
+          return expect(response.data[0].id).toBeTruthy();
+        })
+        .catch(err => {
+          throw err;
+        });
+    });
+
+    test('test photo object product', () => {
+      return axios.get('http://localhost:3001/products/1')
+        .then(response => {
+          return expect(response.data[0].product).toBeTruthy();
+        })
+        .catch(err => {
+          throw err;
+        });
+    });
+
+    test('test photo object url', () => {
+      return axios.get('http://localhost:3001/products/1')
+        .then(response => {
+          return expect(response.data[0].url).toBeTruthy();
+        })
+        .catch(err => {
+          throw err;
+        });
+    });
+
+  }); // end of photo object tests
 
 }); // end of server tests


### PR DESCRIPTION
Improvements to code readability via comments. 

Changed what happens when server receives request to 'products/:id' endpoint. Previously it attempted to create a database connection each time it received a request and this caused an error. It now uses a variable to track whether or not it is connecting for the first time. On the first request, it creates the connection. From that point on, it uses the same connection and avoids this problem. 

Also changed 'response' variable used to describe results of database query, as this was confusing in light of using that result to send a response to the client. Adjusted to 'dbResults' accordingly. 